### PR TITLE
feature: add autocompactionInterval

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ client.on('connect', function() {
 });
 ```
 
+## Automatic compaction
+
+NeDB datastores are compacted by default only when opened. NeDB's automatic
+periodic compaction can be activated with NeDB constructor options:
+
+```
+  manager = NeDBStore('path/to/db', { outgoing: { autocompactionInterval: 60 } });
+```
+
+
+
 ## License
 
 MIT

--- a/mqtt-nedb-store.js
+++ b/mqtt-nedb-store.js
@@ -18,6 +18,9 @@ var Store = function (options) {
 
   this._opts = options || {}
   this.db = new Datastore({ filename: this._opts.filename, autoload: true })
+  if (this._opts.autocompactionInterval) {
+    this.db.persistence.setAutocompactionInterval(Number(this._opts.autocompactionInterval))
+  }
 }
 
 /**
@@ -140,9 +143,13 @@ var Manager = function (path, options) {
 
     }
   }
+  var incomingOptions = (options && options.incoming) || {}
+  incomingOptions.filename = require('path').join(path, 'incoming')
+  this.incoming = new Store(incomingOptions)
 
-  this.incoming = new Store({filename: require('path').join(path, 'incoming')})
-  this.outgoing = new Store({filename: require('path').join(path, 'outgoing')})
+  var outgoingOptions = (options && options.outgoing) || {}
+  outgoingOptions.filename = require('path').join(path, 'outgoing')
+  this.outgoing = new Store(outgoingOptions)
 }
 
 Manager.single = Store;


### PR DESCRIPTION
Add autocompactionInterval options properties to incoming and
outgoing stores.

Fixes #2.

Tested manually, as the mocha tests are broken in master.